### PR TITLE
More JSON and HTTP features

### DIFF
--- a/dsl/src/main/scala/mesosphere/servicenet/dsl/Interface.scala
+++ b/dsl/src/main/scala/mesosphere/servicenet/dsl/Interface.scala
@@ -13,10 +13,3 @@ import java.net.Inet6Address
 case class Interface(
   name: String,
   addr: Either[Inet6Address, Inet6Subnet]) extends NetworkEntity
-
-object Interface {
-  def apply(name: String, addr: Inet6Address): Interface =
-    Interface(name, Left(addr))
-  def apply(name: String, addr: Inet6Subnet): Interface =
-    Interface(name, Right(addr))
-}

--- a/dsl/src/main/scala/mesosphere/servicenet/dsl/package.scala
+++ b/dsl/src/main/scala/mesosphere/servicenet/dsl/package.scala
@@ -1,0 +1,14 @@
+package mesosphere.servicenet
+
+import scala.language.implicitConversions
+import java.net.Inet6Address
+
+package object dsl {
+
+  implicit def inet6Address2Either(
+    addr: Inet6Address): Either[Inet6Address, Inet6Subnet] = Left(addr)
+
+  implicit def inet6Subnet2Either(
+    subnet: Inet6Subnet): Either[Inet6Address, Inet6Subnet] = Right(subnet)
+
+}

--- a/http/src/main/scala/mesosphere/servicenet/http/HTTPServer.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/HTTPServer.scala
@@ -1,22 +1,50 @@
 package mesosphere.servicenet.http
 
+import mesosphere.servicenet.dsl._
 import mesosphere.servicenet.http.json.DocProtocol
-import play.api.libs.json.Json
+import play.api.libs.json._
 import unfiltered.jetty.Http
 import unfiltered.request._
 import unfiltered.response._
 
-class HTTPServer extends DocProtocol {
+class HTTPServer(updated: Doc => Unit = (doc: Doc) => ()) extends DocProtocol {
 
-  def run(port: Int): Unit = {
-    object RestRoutes extends unfiltered.filter.Plan {
-      def intent = {
-        case Path(Seg(p :: Nil)) => ResponseString(p)
-      }
-    }
+  @volatile protected var doc: Doc = Doc(Nil, Nil, Nil, Nil)
 
-    Http(port).filter(RestRoutes).run
+  def update(docPrime: Doc) = synchronized {
+    doc = docPrime
   }
+
+  object RestRoutes extends unfiltered.filter.Plan {
+    def intent = {
+      case req @ Path(Seg("doc" :: Nil)) => req match {
+
+        case GET(_) =>
+          ResponseHeader("Content-Type", Set("application/json")) ~>
+            ResponseString(Json.toJson(doc).toString)
+
+        case PUT(_) =>
+          Json.parse(Body.bytes(req)).validate[Doc] match {
+            case success: JsSuccess[_] =>
+              update(success.get)
+              ResponseString("OK")
+            case error: JsError =>
+              BadRequest ~>
+                ResponseHeader("Content-Type", Set("application/json")) ~>
+                ResponseString(JsError.toFlatJson(error).toString)
+          }
+
+        case PATCH(_) =>
+          MethodNotAllowed ~> ResponseString("Must be GET or PUT")
+      }
+
+      case _ => NotFound ~> ResponseString("Not found")
+    }
+  }
+
+  def run(port: Int): Unit =
+    Http(port).filter(RestRoutes).run
+
 }
 
 object HTTPServer extends App {

--- a/http/src/main/scala/mesosphere/servicenet/http/HTTPServer.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/HTTPServer.scala
@@ -1,10 +1,12 @@
 package mesosphere.servicenet.http
 
+import mesosphere.servicenet.http.json.DocProtocol
+import play.api.libs.json.Json
 import unfiltered.jetty.Http
 import unfiltered.request._
 import unfiltered.response._
 
-class HTTPServer {
+class HTTPServer extends DocProtocol {
 
   def run(port: Int): Unit = {
     object RestRoutes extends unfiltered.filter.Plan {

--- a/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
@@ -88,6 +88,32 @@ trait DocProtocol {
 
   // Add, Remove, Change, Diff
 
+  // See: http://tools.ietf.org/html/rfc6902
+  //
+  // For example:
+  //
+  // {
+  //   "op": "add",
+  //   "path": "interfaces",
+  //   "value": { "label": "my-service", "addr": "fc75:0:0:0:0:9fb2:0:804" }
+  // }
+  //
+  // {
+  //   "op": "remove", "path": "interfaces", "value": "my-service"
+  // }
+
+  // implicit val networkEntityFormat = new Format[NetworkEntity] {
+  //   def writes(entity: NetworkEntity): JsValue = ???
+  //   def reads(json: JsValue): JsResult[NetworkEntity] = ???
+  // }
+
+  // case class Patch(
+  //   op: String,
+  //   path: String,
+  //   value: Change[NetworkEntity])
+
+  // implicit val patchFormat = Json.format[Patch]
+
   implicit val changeInterfaceFormat = new Format[Change[Interface]] {
     def writes(change: Change[Interface]): JsValue = ???
     def reads(json: JsValue): JsResult[Change[Interface]] = ???

--- a/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
@@ -60,9 +60,14 @@ trait DocProtocol {
 
   // DNS
 
+  val aaaaFormat = Json.format[AAAA]
+
   implicit val dnsFormat = new Format[DNS] {
-    def writes(dns: DNS): JsValue = ???
-    def reads(json: JsValue): JsResult[DNS] = ???
+    def writes(dns: DNS): JsValue = dns match {
+      case aaaa: AAAA => aaaaFormat.writes(aaaa)
+    }
+    def reads(json: JsValue): JsResult[DNS] =
+      aaaaFormat.reads(json)
   }
 
   // NAT

--- a/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
@@ -1,0 +1,79 @@
+package mesosphere.servicenet.http.json
+
+import mesosphere.servicenet.dsl._
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import java.net.{ InetAddress, Inet4Address, Inet6Address }
+
+trait DocProtocol {
+
+  // InetAddress, Inet4Address, Inet6Address, Inet6Subnet
+
+  implicit val inet4AddressFormat = new Format[Inet4Address] {
+    def writes(addr: Inet4Address): JsValue = ???
+    def reads(json: JsValue): JsResult[Inet4Address] = ???
+  }
+
+  implicit val inet6AddressFormat = new Format[Inet6Address] {
+    def writes(addr: Inet6Address): JsValue = ???
+    def reads(json: JsValue): JsResult[Inet6Address] = ???
+  }
+
+  implicit val inetAddressFormat = new Format[InetAddress] {
+    def writes(addr: InetAddress): JsValue = addr match {
+      case a: Inet4Address => inet4AddressFormat.writes(a)
+      case a: Inet6Address => inet6AddressFormat.writes(a)
+      case _               => ???
+    }
+
+    def reads(json: JsValue): JsResult[InetAddress] = ???
+  }
+
+  implicit val inet6SubnetFormat = Json.format[Inet6Subnet]
+
+  // Interface
+
+  implicit val interfaceFormat = new Format[Interface] {
+    def writes(interface: Interface): JsValue = ???
+    def reads(json: JsValue): JsResult[Interface] = ???
+  }
+
+  // DNS
+
+  implicit val dnsFormat = new Format[DNS] {
+    def writes(dns: DNS): JsValue = ???
+    def reads(json: JsValue): JsResult[DNS] = ???
+  }
+
+  // NAT
+
+  implicit val natFormat = new Format[NAT] {
+    def writes(nat: NAT): JsValue = ???
+    def reads(json: JsValue): JsResult[NAT] = ???
+  }
+
+  // Tunnel
+
+  implicit val tunnelFormat = new Format[Tunnel] {
+    def writes(tunnel: Tunnel): JsValue = ???
+    def reads(json: JsValue): JsResult[Tunnel] = ???
+  }
+
+  // Add, Remove, Change, Diff
+
+  /*
+  implicit val changeFormat = new Format[Change[_]] {
+    def writes(change: Change[_]): JsValue = ???
+    def reads(json: JsValue): JsResult[Change[_]] = ???
+  }
+
+  implicit val diffFormat = Json.format[Diff]  
+*/
+
+  // Doc
+
+  implicit val docFormat = Json.format[Doc]
+
+}
+
+object DocProtocol extends DocProtocol

--- a/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
@@ -7,6 +7,9 @@ import play.api.libs.functional.syntax._
 import scala.util.{ Try, Success, Failure }
 import java.net.{ InetAddress, Inet4Address, Inet6Address }
 
+/**
+  * Custom JSON (de)serializer logic for Service Net DSL types.
+  */
 trait DocProtocol {
 
   // InetAddress, Inet4Address, Inet6Address, Inet6Subnet
@@ -64,10 +67,7 @@ trait DocProtocol {
 
   // NAT
 
-  implicit val natFormat = new Format[NAT] {
-    def writes(nat: NAT): JsValue = ???
-    def reads(json: JsValue): JsResult[NAT] = ???
-  }
+  implicit val natFormat = Json.format[NAT]
 
   // Tunnel
 
@@ -111,4 +111,7 @@ trait DocProtocol {
 
 }
 
+/**
+  * Custom JSON (de)serializer logic for Service Net DSL types.
+  */
 object DocProtocol extends DocProtocol

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -19,6 +19,11 @@ class DocProtocolSpec extends Spec {
 
     val interface = Interface(name = "my-service", addr = inet6Address)
 
+    val aaaa = AAAA(
+      label = "foo.bar",
+      addresses = Seq(inet6Address)
+    )
+
     val nat = NAT(
       name = "my-nat",
       service = inet6Subnet,
@@ -100,6 +105,18 @@ class DocProtocolSpec extends Spec {
 
     val readResult = json.as[Interface]
     readResult should equal (interface)
+  }
+
+  it should "read and write DNS" in {
+    import Fixture._
+    val json = Json.toJson(aaaa)
+    json should equal (Json.obj(
+      "label" -> "foo.bar",
+      "addresses" -> Json.toJson(Seq(inet6Address))
+    ))
+
+    val readResult = json.as[DNS]
+    readResult should equal (aaaa)
   }
 
   it should "read and write NAT" in {

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -13,6 +13,9 @@ class DocProtocolSpec extends Spec {
 
     val inet6Address =
       InetAddressHelper.ipv6("fc75:0000:0000:0000:0000:9fb2:0000:0804")
+
+    val inet6Subnet =
+      Inet6Subnet(addr = inet6Address, prefixBits = 64)
   }
 
   import DocProtocol._
@@ -39,7 +42,7 @@ class DocProtocolSpec extends Spec {
     }
   }
 
-  "DocProtocol" should "read and write Inet6Address" in {
+  it should "read and write Inet6Address" in {
     import Fixture._
 
     val json = Json.toJson(inet6Address)
@@ -59,7 +62,20 @@ class DocProtocolSpec extends Spec {
     intercept[JsResultException] {
       JsArray(Seq(JsString("one"), JsString("two"))).as[Inet6Address]
     }
+  }
 
+  it should "read and write Inet6ASubnet" in {
+    import Fixture._
+
+    val json = Json.toJson(inet6Subnet)
+
+    json should equal (Json.obj(
+      "addr" -> "fc75:0:0:0:0:9fb2:0:804",
+      "prefixBits" -> 64
+    ))
+
+    val readResult = json.as[Inet6Subnet]
+    readResult should equal (inet6Subnet)
   }
 
 }

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -1,0 +1,65 @@
+package mesosphere.servicenet.http.json
+
+import mesosphere.servicenet.dsl._
+import mesosphere.servicenet.util.{ InetAddressHelper, Spec }
+import play.api.libs.json._
+import play.api.libs.functional.syntax._
+import java.net.{ InetAddress, Inet4Address, Inet6Address }
+
+class DocProtocolSpec extends Spec {
+
+  object Fixture {
+    val inet4Address = InetAddressHelper.ipv4("192.168.1.115")
+
+    val inet6Address =
+      InetAddressHelper.ipv6("fc75:0000:0000:0000:0000:9fb2:0000:0804")
+  }
+
+  import DocProtocol._
+
+  "DocProtocol" should "read and write Inet4Address" in {
+    import Fixture._
+
+    val json = Json.toJson(inet4Address)
+    json should equal (JsString("192.168.1.115"))
+
+    val readResult = json.as[Inet4Address]
+    readResult should equal (inet4Address)
+
+    intercept[JsResultException] {
+      JsString("one fish two fish").as[Inet4Address]
+    }
+
+    intercept[JsResultException] {
+      JsString("FC75:0000:0000:0000:0000:9FB2:0000:0804").as[Inet4Address]
+    }
+
+    intercept[JsResultException] {
+      JsArray(Seq(JsString("one"), JsString("two"))).as[Inet4Address]
+    }
+  }
+
+  "DocProtocol" should "read and write Inet6Address" in {
+    import Fixture._
+
+    val json = Json.toJson(inet6Address)
+    json should equal (JsString("fc75:0:0:0:0:9fb2:0:804"))
+
+    val readResult = json.as[Inet6Address]
+    readResult should equal (inet6Address)
+
+    intercept[JsResultException] {
+      JsString("one fish two fish").as[Inet6Address]
+    }
+
+    intercept[JsResultException] {
+      JsString("192.168.1.115").as[Inet6Address]
+    }
+
+    intercept[JsResultException] {
+      JsArray(Seq(JsString("one"), JsString("two"))).as[Inet6Address]
+    }
+
+  }
+
+}

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -37,6 +37,14 @@ class DocProtocolSpec extends Spec {
       addr = inet6Address,
       remoteIPv6Net = inet6Subnet
     )
+
+    val doc = Doc(
+      interfaces = Seq(interface),
+      dns = Seq(aaaa),
+      nat = Seq(nat),
+      tunnels = Seq(tunnel)
+    )
+
   }
 
   import DocProtocol._
@@ -145,6 +153,20 @@ class DocProtocolSpec extends Spec {
 
     val readResult = json.as[Tunnel]
     readResult should equal (tunnel)
+  }
+
+  it should "read and write Doc" in {
+    import Fixture._
+    val json = Json.toJson(doc)
+    json should equal (Json.obj(
+      "interfaces" -> Json.toJson(Seq(interface)),
+      "dns" -> Json.toJson(Seq(aaaa)),
+      "nat" -> Json.toJson(Seq(nat)),
+      "tunnels" -> Json.toJson(Seq(tunnel))
+    ))
+
+    val readResult = json.as[Doc]
+    readResult should equal (doc)
   }
 
 }

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -19,6 +19,12 @@ class DocProtocolSpec extends Spec {
 
     val interface = Interface(name = "my-service", addr = inet6Address)
 
+    val nat = NAT(
+      name = "my-nat",
+      service = inet6Subnet,
+      instances = Seq(inet6Address, inet6Address)
+    )
+
     val tunnel = Tunnel6in4(
       name = "my-tunnel",
       localEnd = inet4Address,
@@ -94,6 +100,19 @@ class DocProtocolSpec extends Spec {
 
     val readResult = json.as[Interface]
     readResult should equal (interface)
+  }
+
+  it should "read and write NAT" in {
+    import Fixture._
+    val json = Json.toJson(nat)
+    json should equal (Json.obj(
+      "name" -> "my-nat",
+      "service" -> Json.toJson(inet6Subnet),
+      "instances" -> Json.toJson(Seq(inet6Address, inet6Address))
+    ))
+
+    val readResult = json.as[NAT]
+    readResult should equal (nat)
   }
 
   it should "read and write Tunnel" in {

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -16,13 +16,22 @@ class DocProtocolSpec extends Spec {
 
     val inet6Subnet =
       Inet6Subnet(addr = inet6Address, prefixBits = 64)
+
+    val interface = Interface(name = "my-service", addr = inet6Address)
+
+    val tunnel = Tunnel6in4(
+      name = "my-tunnel",
+      localEnd = inet4Address,
+      remoteEnd = inet4Address,
+      addr = inet6Address,
+      remoteIPv6Net = inet6Subnet
+    )
   }
 
   import DocProtocol._
 
   "DocProtocol" should "read and write Inet4Address" in {
     import Fixture._
-
     val json = Json.toJson(inet4Address)
     json should equal (JsString("192.168.1.115"))
 
@@ -44,7 +53,6 @@ class DocProtocolSpec extends Spec {
 
   it should "read and write Inet6Address" in {
     import Fixture._
-
     val json = Json.toJson(inet6Address)
     json should equal (JsString("fc75:0:0:0:0:9fb2:0:804"))
 
@@ -66,9 +74,7 @@ class DocProtocolSpec extends Spec {
 
   it should "read and write Inet6ASubnet" in {
     import Fixture._
-
     val json = Json.toJson(inet6Subnet)
-
     json should equal (Json.obj(
       "addr" -> "fc75:0:0:0:0:9fb2:0:804",
       "prefixBits" -> 64
@@ -76,6 +82,33 @@ class DocProtocolSpec extends Spec {
 
     val readResult = json.as[Inet6Subnet]
     readResult should equal (inet6Subnet)
+  }
+
+  it should "read and write Interface" in {
+    import Fixture._
+    val json = Json.toJson(interface)
+    json should equal (Json.obj(
+      "name" -> "my-service",
+      "addr" -> inet6Address
+    ))
+
+    val readResult = json.as[Interface]
+    readResult should equal (interface)
+  }
+
+  it should "read and write Tunnel" in {
+    import Fixture._
+    val json = Json.toJson(tunnel)
+    json should equal (Json.obj(
+      "name" -> "my-tunnel",
+      "localEnd" -> Json.toJson(inet4Address),
+      "remoteEnd" -> Json.toJson(inet4Address),
+      "addr" -> Json.toJson(inet6Address),
+      "remoteIPv6Net" -> Json.toJson(inet6Subnet)
+    ))
+
+    val readResult = json.as[Tunnel]
+    readResult should equal (tunnel)
   }
 
 }

--- a/ns/src/main/scala/mesosphere/servicenet/ns/NameServer.scala
+++ b/ns/src/main/scala/mesosphere/servicenet/ns/NameServer.scala
@@ -2,7 +2,7 @@ package mesosphere.servicenet.ns
 
 import mesosphere.servicenet
 import mesosphere.servicenet.dsl.{ AAAA, Doc, Diff }
-import mesosphere.servicenet.util.Logging
+import mesosphere.servicenet.util.{ InetAddressHelper, Logging }
 import akka.actor._
 import akka.pattern.ask
 import akka.io.IO
@@ -121,22 +121,6 @@ class NameServer extends Logging {
   protected def toDns4s(msg: DNS.Message): dns4s.Message =
     dns4s.Message(dns4s.MessageBuffer().put(msg.toWire).flipped)
 
-  /**
-    * Returns a canonical `java.net.Inet6Address` for the supplied address
-    * string.
-    *
-    * @param addr An IPv6 Address (32 hexadecimal digits)
-    */
-  @throws[java.net.UnknownHostException]
-  def ipv6Address(addr: String): Inet6Address =
-    InetAddress.getByAddress(bytes(addr)).asInstanceOf[Inet6Address]
-
-  protected[this] val hexChars: Set[Char] =
-    (('0' to '9') ++ ('A' to 'Z') ++ ('a' to 'z')).toSet
-
-  protected[this] def bytes(s: String): Array[Byte] =
-    s.filter(hexChars).sliding(2, 2).map(BigInt(_, 16).toByte).toArray
-
 }
 
 /**
@@ -147,10 +131,10 @@ object NameServer extends App {
 
   val testDoc = {
     val loopbackAddress =
-      ns.ipv6Address("0000 0000 0000 0000 0000 0000 0000 0001")
+      InetAddressHelper.ipv6("0000 0000 0000 0000 0000 0000 0000 0001")
 
     val anotherAddress =
-      ns.ipv6Address("FC75 0000 0000 0000 0000 9FB2 0000 0804")
+      InetAddressHelper.ipv6("fc75:0000:0000:0000:0000:9fb2:0000:0804")
 
     Doc(
       interfaces = Nil,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -29,6 +29,7 @@ object ServiceNetBuild extends Build {
   val DNS4S_VERSION           = "0.4-SNAPSHOT"
   val DNSJAVA_VERSION         = "2.1.6"
   val LOGBACK_VERSION         = "1.1.2"
+  val PLAY_JSON_VERSION       = "2.2.3"
   val SLF4J_VERSION           = "1.7.6"
   val UNFILTERED_VERSION      = "0.7.1"
   val TYPESAFE_CONFIG_VERSION = "1.2.0"
@@ -68,8 +69,9 @@ object ServiceNetBuild extends Build {
     base = file("http"),
     settings = commonSettings ++ Seq(
       libraryDependencies ++= Seq(
-        "net.databinder" %% "unfiltered-filter" % UNFILTERED_VERSION,
-        "net.databinder" %% "unfiltered-jetty"  % UNFILTERED_VERSION
+        "net.databinder"    %% "unfiltered-filter" % UNFILTERED_VERSION,
+        "net.databinder"    %% "unfiltered-jetty"  % UNFILTERED_VERSION,
+        "com.typesafe.play" %% "play-json"         % PLAY_JSON_VERSION
       )
     )
   ).dependsOn(dsl, util)
@@ -104,6 +106,7 @@ object ServiceNetBuild extends Build {
     )
   )
 
+
   //////////////////////////////////////////////////////////////////////////////
   // SHARED SETTINGS
   //////////////////////////////////////////////////////////////////////////////
@@ -116,8 +119,10 @@ object ServiceNetBuild extends Build {
     organization := ORGANIZATION,
     scalaVersion := SCALA_VERSION,
 
-    resolvers +=
-      "Mesosphere Repo" at "http://downloads.mesosphere.io/maven",
+    resolvers ++= Seq(
+      "Mesosphere Repo"     at "http://downloads.mesosphere.io/maven",
+      "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
+    ),
 
     libraryDependencies ++= Seq(
       "com.typesafe"   % "config"    % TYPESAFE_CONFIG_VERSION,

--- a/util/src/main/scala/mesosphere/servicenet/util/InetAddressHelper.scala
+++ b/util/src/main/scala/mesosphere/servicenet/util/InetAddressHelper.scala
@@ -1,0 +1,35 @@
+package mesosphere.servicenet.util
+
+import java.net.{ InetAddress, Inet4Address, Inet6Address }
+
+object InetAddressHelper {
+
+  /**
+    * Returns a canonical `java.net.Inet6Address` for the supplied address
+    * string.
+    *
+    * @param addr A well-formed IPv6 Address
+    */
+  @throws[java.net.UnknownHostException]
+  def ipv6(addr: String): Inet6Address =
+    InetAddress.getByName(addr) match {
+      case inet: Inet4Address =>
+        throw new IllegalArgumentException("An IPv4 address was supplied")
+      case inet: Inet6Address => inet
+    }
+
+  /**
+    * Returns a canonical `java.net.Inet4Address` for the supplied address
+    * string.
+    *
+    * @param addr A well-formed IPv4 Address
+    */
+  @throws[java.net.UnknownHostException]
+  def ipv4(addr: String): Inet4Address =
+    InetAddress.getByName(addr) match {
+      case inet: Inet4Address => inet
+      case inet: Inet6Address =>
+        throw new IllegalArgumentException("An IPv6 address was supplied")
+    }
+
+}


### PR DESCRIPTION
Demo session with the HTTP endpoints:

```
connor@mabuya:~ $ http localhost:9000/doc
HTTP/1.1 200 OK
Content-Length: 48
Server: Jetty(8.1.13.v20130916)

{"interfaces":[],"dns":[],"nat":[],"tunnels":[]}

connor@mabuya:~ $ http PATCH localhost:9000/doc
HTTP/1.1 405 Method Not Allowed
Content-Length: 18
Server: Jetty(8.1.13.v20130916)

Must be GET or PUT

connor@mabuya:~ $ http PUT localhost:9000/doc interfaces:='[]'
HTTP/1.1 400 Bad Request
Content-Length: 158
Content-Type: application/json
Server: Jetty(8.1.13.v20130916)

{
    "obj.dns": [
        {
            "args": [], 
            "msg": "error.path.missing"
        }
    ], 
    "obj.nat": [
        {
            "args": [], 
            "msg": "error.path.missing"
        }
    ], 
    "obj.tunnels": [
        {
            "args": [], 
            "msg": "error.path.missing"
        }
    ]
}

connor@mabuya:~ $ http PUT localhost:9000/doc < doc.json
HTTP/1.1 200 OK
Content-Length: 2
Server: Jetty(8.1.13.v20130916)

OK

connor@mabuya:~ $ http GET localhost:9000/doc --pretty format
HTTP/1.1 200 OK
Content-Length: 480
Content-Type: application/json
Server: Jetty(8.1.13.v20130916)

{
    "dns": [
        {
            "addresses": [
                "fc75:0:0:0:0:9fb2:0:804"
            ], 
            "label": "foo.bar"
        }
    ], 
    "interfaces": [
        {
            "addr": "fc75:0:0:0:0:9fb2:0:804", 
            "name": "my-service"
        }
    ], 
    "nat": [
        {
            "instances": [
                "fc75:0:0:0:0:9fb2:0:804", 
                "fc75:0:0:0:0:9fb2:0:804"
            ], 
            "name": "my-nat", 
            "service": {
                "addr": "fc75:0:0:0:0:9fb2:0:804", 
                "prefixBits": 64
            }
        }
    ], 
    "tunnels": [
        {
            "addr": "fc75:0:0:0:0:9fb2:0:804", 
            "localEnd": "192.168.1.115", 
            "name": "my-tunnel", 
            "remoteEnd": "192.168.1.115", 
            "remoteIPv6Net": {
                "addr": "fc75:0:0:0:0:9fb2:0:804", 
                "prefixBits": 64
            }
        }
    ]
}
```
