### PR TITLE
Allow interfaces to have multiple IPs.

### DIFF
--- a/dsl/src/main/scala/mesosphere/servicenet/dsl/Interface.scala
+++ b/dsl/src/main/scala/mesosphere/servicenet/dsl/Interface.scala
@@ -8,16 +8,12 @@ import java.net.Inet6Address
   * interface, as well as creating the interface with the given IP.
   *
   * @param name interface device name
-  * @param addr an IPv6 IP or subnet
+  * @param addrs IPv6 IPs to assign to this interface
   */
-case class Interface(name: String,
-                     addr: Either[Inet6Address, Inet6Subnet])
-    extends NetworkEntity
+case class Interface(name: String, addrs: Seq[Inet6Address])
+  extends NetworkEntity
 
 object Interface {
   def apply(name: String, addr: Inet6Address): Interface =
-    Interface(name, Left(addr))
-
-  def apply(name: String, net: Inet6Subnet): Interface =
-    Interface(name, Right(net))
+    Interface(name, Seq(addr))
 }

--- a/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
+++ b/http/src/main/scala/mesosphere/servicenet/http/json/DocProtocol.scala
@@ -59,25 +59,9 @@ trait DocProtocol {
 
   // Interface
 
-  implicit val addressOrSubnetFormat =
-    new Format[Either[Inet6Address, Inet6Subnet]] {
-      def writes(v: Either[Inet6Address, Inet6Subnet]): JsValue =
-        v match {
-          case Left(addr)    => inet6AddressFormat writes addr
-          case Right(subnet) => inet6SubnetFormat writes subnet
-        }
-      def reads(json: JsValue): JsResult[Either[Inet6Address, Inet6Subnet]] =
-        json match {
-          case _: JsString =>
-            inet6AddressFormat.reads(json).map(Left(_)) orElse
-              inet6SubnetFormat.reads(json).map(Right(_))
-          case _ => JsError("Address or subnet must be a string")
-        }
-    }
-
   implicit val interfaceFormat: Format[Interface] = (
     (__ \ "name").format[String] and
-    (__ \ "addr").format[Either[Inet6Address, Inet6Subnet]]
+    (__ \ "addrs").format[Seq[Inet6Address]]
   )(Interface.apply(_, _), unlift(Interface.unapply))
 
   // DNS

--- a/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
+++ b/http/src/test/scala/mesosphere/servicenet/http/json/DocProtocolSpec.scala
@@ -17,7 +17,7 @@ class DocProtocolSpec extends Spec {
     val inet6Subnet =
       Inet6Subnet(addr = inet6Address, prefixBits = 64)
 
-    val interface = Interface(name = "my-service", addr = inet6Address)
+    val interface = Interface(name = "my-service", addrs = Seq(inet6Address))
 
     val aaaa = AAAA(
       label = "foo.bar",
@@ -105,7 +105,7 @@ class DocProtocolSpec extends Spec {
     val json = Json.toJson(interface)
     json should equal (Json.obj(
       "name" -> "my-service",
-      "addr" -> inet6Address
+      "addrs" -> Json.arr(inet6Address)
     ))
 
     val readResult = json.as[Interface]

--- a/patch/src/main/scala/mesosphere/servicenet/patch/bash/Command.scala
+++ b/patch/src/main/scala/mesosphere/servicenet/patch/bash/Command.scala
@@ -12,10 +12,8 @@ object Command {
   case class Interface(change: dsl.Change[dsl.Interface]) extends Command {
     val command = change match {
       case dsl.Remove(name) => Seq("rm", "dummy", name)
-      case dsl.Add(item) => item.addr match {
-        case Right(net) => Seq("dummy", item.name, net.getCanonicalForm)
-        case Left(ip)   => Seq("dummy", item.name, ip.getHostAddress)
-      }
+      case dsl.Add(item) =>
+        Seq("dummy", item.name) ++ item.addrs.map(_.getHostAddress)
     }
   }
 


### PR DESCRIPTION
Subnets for interfaces have been dropped. Perhaps it is better to require
explicit specifications of routes, in any event.
